### PR TITLE
Replace File class with Blob + name field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/uploadthing/make-transparent-file.ts
+++ b/src/app/api/uploadthing/make-transparent-file.ts
@@ -54,10 +54,16 @@ export const uploadTransparent = async (url: string) => {
 
   const blobFromBody: Blob = await streamToBlob(r, "image/png");
 
-  const f = new File([blobFromBody], "transparent.png", { type: "image/png" });
+  const mockFile = Object.assign(
+    {},
+    blobFromBody,
+    {
+      name: "transparent.png",
+    }
+  ) as File;
 
   const uploadedFiles = await DANGEROUS__uploadFiles(
-    [f],
+    [mockFile],
     "transparentUploader",
 
     // TODO: Make this unnecessary


### PR DESCRIPTION
File class is extending Blob class with very little addition. I checked uploadthing internals and it relies only on Blob capabilities in most cases except for name

There was already instance of blob so I just created new object that has everything Blob posesses + name. Using `as` operator to become friends with TSC